### PR TITLE
Feature/user session persistence

### DIFF
--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,3 +1,13 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-export default class LoginRoute extends Route {}
+export default class LoginRoute extends Route {
+  @service auth;
+  @service router;
+
+  beforeModel() {
+    if (this.auth.isAuthenticated()) {
+      this.router.transitionTo('tickets');
+    }
+  }
+}

--- a/app/routes/signup.js
+++ b/app/routes/signup.js
@@ -1,3 +1,13 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
-export default class SignupRoute extends Route {}
+export default class LoginRoute extends Route {
+  @service auth;
+  @service router;
+
+  beforeModel() {
+    if (this.auth.isAuthenticated()) {
+      this.router.transitionTo('tickets');
+    }
+  }
+}

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -41,7 +41,10 @@ export default class AuthService extends Service {
         }
       `;
 
-      const result = await this.apollo.query({ query, fetchPolicy: 'network-only' });
+      const result = await this.apollo.query({
+        query,
+        fetchPolicy: 'network-only',
+      });
       this.user = result?.currentUser;
     } catch (error) {
       console.error('Failed to auto-fetch user:', error);

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -1,12 +1,52 @@
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import jwtDecode from 'jwt-decode';
+import gql from 'graphql-tag';
 
 export default class AuthService extends Service {
+  @service apollo;
+
   @tracked user = null;
   @tracked token = localStorage.getItem('token');
 
+  constructor() {
+    super(...arguments);
+    this.initializeUser();
+  }
+
   isAuthenticated() {
     return !!this.token;
+  }
+
+  async initializeUser() {
+    if (!this.token) return;
+
+    try {
+      const decoded = jwtDecode(this.token);
+      const now = Math.floor(Date.now() / 1000);
+      if (decoded.exp < now) {
+        this.logout();
+        return;
+      }
+
+      const query = gql`
+        query {
+          currentUser {
+            id
+            email
+            name
+            role
+          }
+        }
+      `;
+
+      const result = await this.apollo.query({ query, fetchPolicy: 'network-only' });
+      this.user = result?.currentUser;
+    } catch (error) {
+      console.error('Failed to auto-fetch user:', error);
+      this.logout();
+    }
   }
 
   login(token, userData) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@rails/activestorage": "^8.0.200"
+        "@rails/activestorage": "^8.0.200",
+        "jwt-decode": "^4.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.27.1",
@@ -20633,6 +20634,15 @@
       "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "edition": "octane"
   },
   "dependencies": {
-    "@rails/activestorage": "^8.0.200"
+    "@rails/activestorage": "^8.0.200",
+    "jwt-decode": "^4.0.0"
   }
 }


### PR DESCRIPTION
In this branch, I imlemented the following:

### 1. Enhanced auth.js Service

-   Loaded token from localStorage on boot.

-   Optionally decoded token (if JWT decode was implemented).

-   Fetched and tracked user profile.

### 2. Auto-Fetch User Profile

-   Either decoded the token or queried the GraphQL currentUser endpoint on app boot to set auth.user.

### 3. Handled Route Guarding

-   In login.js and signup.js routes:

-    Checked if user is already authenticated.

-    Redirect to /tickets