### PR TITLE
Feature/access control guards

### DIFF
--- a/app/routes/agent/tickets.js
+++ b/app/routes/agent/tickets.js
@@ -1,3 +1,15 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import redirectIfNotAuthenticated from '../../../utils/redirect-if-not-authenticated';
 
-export default class AgentTicketsRoute extends Route {}
+export default class AgentTicketsRoute extends Route {
+  @service auth;
+  @service router;
+
+  beforeModel() {
+    if (redirectIfNotAuthenticated(this.auth, this.router)) return;
+    if (this.auth.user?.role !== 'agent') {
+      this.router.transitionTo('tickets');
+    }
+  }
+}

--- a/app/routes/agent/tickets/detail.js
+++ b/app/routes/agent/tickets/detail.js
@@ -1,3 +1,15 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import redirectIfNotAuthenticated from '../../../utils/redirect-if-not-authenticated';
 
-export default class AgentTicketsDetailRoute extends Route {}
+export default class AgentTicketsRoute extends Route {
+  @service auth;
+  @service router;
+
+  beforeModel() {
+    if (redirectIfNotAuthenticated(this.auth, this.router)) return;
+    if (this.auth.user?.role !== 'agent') {
+      this.router.transitionTo('tickets');
+    }
+  }
+}

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service auth;
+
+  async beforeModel() {
+    await this.auth.restoreSession();
+  }
+}

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -7,7 +7,11 @@ export default class LoginRoute extends Route {
 
   beforeModel() {
     if (this.auth.isAuthenticated()) {
-      this.router.transitionTo('tickets');
+      if (this.auth.user?.role === 'agent') {
+        this.router.transitionTo('agent.tickets');
+      } else {
+        this.router.transitionTo('tickets');
+      }
     }
   }
 }

--- a/app/routes/signup.js
+++ b/app/routes/signup.js
@@ -7,7 +7,11 @@ export default class LoginRoute extends Route {
 
   beforeModel() {
     if (this.auth.isAuthenticated()) {
-      this.router.transitionTo('tickets');
+      if (this.auth.user?.role === 'agent') {
+        this.router.transitionTo('agent.tickets');
+      } else {
+        this.router.transitionTo('tickets');
+      }
     }
   }
 }

--- a/app/routes/tickets.js
+++ b/app/routes/tickets.js
@@ -1,9 +1,19 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import gql from 'graphql-tag';
+import redirectIfNotAuthenticated from '../utils/redirect-if-not-authenticated';
 
 export default class TicketsRoute extends Route {
+  @service auth;
+  @service router;
   @service apollo;
+
+  beforeModel() {
+    if (redirectIfNotAuthenticated(this.auth, this.router)) return;
+    if (this.auth.user?.role !== 'customer') {
+      this.router.transitionTo('agent.tickets');
+    }
+  }
 
   async model() {
     const query = gql`

--- a/app/routes/tickets/details.js
+++ b/app/routes/tickets/details.js
@@ -1,9 +1,19 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { GET_TICKET_DETAIL } from '../../graphql/queries/tickets';
+import redirectIfNotAuthenticated from '../../utils/redirect-if-not-authenticated';
 
 export default class TicketsDetailRoute extends Route {
+  @service auth;
+  @service router;
   @service apollo;
+
+  beforeModel() {
+    if (redirectIfNotAuthenticated(this.auth, this.router)) return;
+    if (this.auth.user?.role !== 'customer') {
+      this.router.transitionTo('agent.tickets');
+    }
+  }
 
   async model(params) {
     const response = await this.apollo.query({

--- a/app/utils/redirect-if-not-authenticated.js
+++ b/app/utils/redirect-if-not-authenticated.js
@@ -1,0 +1,7 @@
+export default function redirectIfNotAuthenticated(auth, router) {
+  if (!auth.isAuthenticated()) {
+    router.transitionTo('login');
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## In this PR. I have implemented access control guards across the application to ensure that only authorized users can access specific routes. It introduces a reusable redirectIfNotAuthenticated utility and uses role-based redirection to improve route-level protection.

### These are the changes:

**1. Added beforeModel() hooks to:**

-   routes/tickets.js and routes/tickets/detail.js to:

-   Block unauthenticated users

-   Redirect agents from customer views to agent.tickets

**2. Reused redirectIfNotAuthenticated(auth, router) across routes**